### PR TITLE
Unset "Pragma" headers to avoid wrong caching behaviour

### DIFF
--- a/code/policies/BackwardsCompatibleCachingPolicy.php
+++ b/code/policies/BackwardsCompatibleCachingPolicy.php
@@ -63,7 +63,9 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy 
 
 		if($cacheAge > 0) {
 			$responseHeaders["Cache-Control"] = "max-age=" . $cacheAge . ", must-revalidate, no-transform";
-			$responseHeaders["Pragma"] = "";
+			if(isset($responseHeaders["Pragma"])) {
+			 	unset($responseHeaders["Pragma"]);
+			 }
 			$responseHeaders['Vary'] = $this->vary;
 		}
 		else {
@@ -83,7 +85,9 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy 
 				// (http://support.microsoft.com/kb/323308)
 				// Note: this is also fixable by ticking "Do not save encrypted pages to disk" in advanced options.
 				$responseHeaders["Cache-Control"] = "max-age=3, must-revalidate, no-transform";
-				$responseHeaders["Pragma"] = "";
+				if(isset($responseHeaders["Pragma"])) {
+					unset($responseHeaders["Pragma"]);
+				}
 			} else {
 				$responseHeaders["Cache-Control"] = "no-cache, max-age=0, must-revalidate, no-transform";
 			}

--- a/code/policies/BackwardsCompatibleCachingPolicy.php
+++ b/code/policies/BackwardsCompatibleCachingPolicy.php
@@ -63,9 +63,11 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy 
 
 		if($cacheAge > 0) {
 			$responseHeaders["Cache-Control"] = "max-age=" . $cacheAge . ", must-revalidate, no-transform";
+			
 			if(isset($responseHeaders["Pragma"])) {
-			 	unset($responseHeaders["Pragma"]);
-			 }
+				unset($responseHeaders["Pragma"]);
+			}
+
 			$responseHeaders['Vary'] = $this->vary;
 		}
 		else {
@@ -85,6 +87,7 @@ class BackwardsCompatibleCachingPolicy extends HTTP implements ControllerPolicy 
 				// (http://support.microsoft.com/kb/323308)
 				// Note: this is also fixable by ticking "Do not save encrypted pages to disk" in advanced options.
 				$responseHeaders["Cache-Control"] = "max-age=3, must-revalidate, no-transform";
+				
 				if(isset($responseHeaders["Pragma"])) {
 					unset($responseHeaders["Pragma"]);
 				}

--- a/code/policies/CachingPolicy.php
+++ b/code/policies/CachingPolicy.php
@@ -44,7 +44,9 @@ class CachingPolicy extends HTTP implements ControllerPolicy {
 		if($cacheAge > 0) {
 			// Note: must-revalidate means that the cache must revalidate AFTER the entry has gone stale.
 			$responseHeaders["Cache-Control"] = "max-age=" . $cacheAge . ", must-revalidate, no-transform";
-			$responseHeaders["Pragma"] = "";
+			if(isset($responseHeaders["Pragma"])) {
+			 	unset($responseHeaders["Pragma"]);
+			 }
 			$responseHeaders['Vary'] = $vary;
 
 			// Find out when the URI was last modified. Allows customisation, but fall back HTTP timestamp collector.

--- a/code/policies/CachingPolicy.php
+++ b/code/policies/CachingPolicy.php
@@ -44,9 +44,11 @@ class CachingPolicy extends HTTP implements ControllerPolicy {
 		if($cacheAge > 0) {
 			// Note: must-revalidate means that the cache must revalidate AFTER the entry has gone stale.
 			$responseHeaders["Cache-Control"] = "max-age=" . $cacheAge . ", must-revalidate, no-transform";
+			
 			if(isset($responseHeaders["Pragma"])) {
 			 	unset($responseHeaders["Pragma"]);
-			 }
+			}
+			
 			$responseHeaders['Vary'] = $vary;
 
 			// Find out when the URI was last modified. Allows customisation, but fall back HTTP timestamp collector.


### PR DESCRIPTION
Some HTTP layers like Incapsula will prevent caching
based on the presence of "Pragma", rather than checking for "no-cache".