### PR TITLE
API phpunit 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.2"
+        "silverstripe/framework": "^4.10"
     },
     "require-dev": {
-        "sminnee/phpunit": "^5",
+        "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": "^3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
         }
     ],
     "require": {
+        "php": "^7.3 || ^8.0",
         "silverstripe/framework": "^4.10"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,9 @@
 <phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
-
-    <testsuite name="Default">
-        <directory>tests/</directory>
-    </testsuite>
-
+    <testsuites>
+        <testsuite name="Default">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src/</directory>

--- a/tests/CachingPolicyTest.php
+++ b/tests/CachingPolicyTest.php
@@ -34,7 +34,7 @@ class CachingPolicyTest extends FunctionalTest
         ],
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class CachingPolicyTest extends FunctionalTest
      * Remove any policies from the middleware, since it's assigned to the Director singleton and shared between
      * tests.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach (Director::singleton()->getMiddlewares() as $middleware) {
             if ($middleware instanceof ControllerPolicyMiddleware) {
@@ -90,8 +90,8 @@ class CachingPolicyTest extends FunctionalTest
         $directives = $this->getCsvAsArray($response->getHeader('Cache-Control'));
 
         $this->assertCount(2, $directives);
-        $this->assertContains('max-age=999', $directives);
-        $this->assertContains('must-revalidate', $directives);
+        $this->assertStringContainsString('max-age=999', $directives);
+        $this->assertStringContainsString('must-revalidate', $directives);
 
         $vary = $this->getCsvAsArray($response->getHeader('Vary'));
         $this->assertArraySubset(
@@ -99,7 +99,7 @@ class CachingPolicyTest extends FunctionalTest
             $vary,
             'Retains default Vary'
         );
-        $this->assertContains('X-EyeColour', $vary, 'Adds custom vary');
+        $this->assertStringContainsString('X-EyeColour', $vary, 'Adds custom vary');
     }
 
     public function testCallbackOverride()
@@ -113,12 +113,16 @@ class CachingPolicyTest extends FunctionalTest
         $directives = $this->getCsvAsArray($response->getHeader('Cache-Control'));
 
         $this->assertCount(2, $directives);
-        $this->assertContains('max-age=1001', $directives);
-        $this->assertContains('must-revalidate', $directives);
+        $this->assertStringContainsString('max-age=1001', $directives);
+        $this->assertStringContainsString('must-revalidate', $directives);
 
         $vary = $this->getCsvAsArray($response->getHeader('Vary'));
-        $this->assertContains('X-HeightWeight', $vary, 'Controller\'s getVary() overrides the configuration');
-        $this->assertNotContains('X-EyeColour', $vary);
+        $this->assertStringContainsString(
+            'X-HeightWeight',
+            $vary,
+            'Controller\'s getVary() overrides the configuration'
+        );
+        $this->assertStringNotContainsString('X-EyeColour', $vary);
 
         $this->assertEquals(
             HTTP::gmt_date('5000'),

--- a/tests/CustomHeaderPolicyTest.php
+++ b/tests/CustomHeaderPolicyTest.php
@@ -24,7 +24,7 @@ class CustomHeaderPolicyTest extends SapphireTest
      */
     protected $policy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PageControlledPolicyTest.php
+++ b/tests/PageControlledPolicyTest.php
@@ -24,7 +24,7 @@ class PageControlledPolicyTest extends SapphireTest
         ],
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10019

This unit tests are currently very broken, for instance this previously worked

```
$this->assertCount(2, $directives);
$this->assertContains('max-age=999', $directives);
$this->assertContains('must-revalidate', $directives);
```

however now $directives is now
  [0]=> "no-cache"
  [1]=> "no-store"
  [2]=> "must-revalidate"

This is probably because of the HTTP caching header work that is now part of Silverstripe core

I'd recommend this entire module be archived as it has been superseded by core functionality

